### PR TITLE
TECH-9393: add opt-in queue_type option for explicit x-queue-type declares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.2
+
+* Add opt-in `queue_type:` option per queue config (e.g. `queue_type: :quorum`) to declare `x-queue-type` explicitly instead of relying on the broker's `default_queue_type` resolution. Defaults to `nil` (unchanged behavior — no explicit type). See [TECH-9393](https://smartrent.atlassian.net/browse/TECH-9393): on RabbitMQ 3.13.x, a broken vhost-metadata fallback path means type-less declares always resolve to `classic` regardless of node config, which silently broke `TaskBunny.Worker`'s consumer reconnect after an out-of-band migration to quorum queues.
+
 ## 0.3.4
 
 * Managing publisher connections with poolboy. [#65](https://github.com/shinyscorpion/task_bunny/pull/65).

--- a/lib/task_bunny/config.ex
+++ b/lib/task_bunny/config.ex
@@ -92,7 +92,8 @@ defmodule TaskBunny.Config do
         queue: queue[:name],
         concurrency: concurrency,
         store_rejected_jobs: store_rejected_jobs,
-        host: queue[:host] || :default
+        host: queue[:host] || :default,
+        queue_type: queue[:queue_type]
       ]
     end)
   end

--- a/lib/task_bunny/initializer.ex
+++ b/lib/task_bunny/initializer.ex
@@ -82,11 +82,12 @@ defmodule TaskBunny.Initializer do
   defp declare_queue(queue_config) do
     queue = queue_config[:name]
     host = queue_config[:host] || :default
+    queue_type = queue_config[:queue_type]
 
     TaskBunny.Connection.subscribe_connection(host, self())
 
     receive do
-      {:connected, conn} -> declare_queue(conn, queue)
+      {:connected, conn} -> declare_queue(conn, queue, queue_type)
     after
       2_000 ->
         Logger.warning("""
@@ -98,9 +99,9 @@ defmodule TaskBunny.Initializer do
     :ok
   end
 
-  @spec declare_queue(AMQP.Connection.t(), String.t()) :: :ok
-  defp declare_queue(conn, queue) do
-    Queue.declare_with_subqueues(conn, queue)
+  @spec declare_queue(AMQP.Connection.t(), String.t(), atom | nil) :: :ok
+  defp declare_queue(conn, queue, queue_type) do
+    Queue.declare_with_subqueues(conn, queue, queue_type: queue_type)
     :ok
   catch
     :exit, e ->

--- a/lib/task_bunny/queue.ex
+++ b/lib/task_bunny/queue.ex
@@ -25,40 +25,53 @@ defmodule TaskBunny.Queue do
   - normal_jobs.retry: a queue that holds jobs failed and waiting to retry
   - normal_jobs.rejected: a queue that holds jobs failed and won't be retried
 
+  Pass `queue_type: :quorum` (or `:classic`) to declare all four queues with
+  an explicit `x-queue-type` argument instead of leaving it unset. Defaults
+  to `nil`, which preserves prior behavior exactly (no explicit type — the
+  broker's own default-queue-type resolution decides).
   """
-  @spec declare_with_subqueues(AMQP.Connection.t() | atom, String.t()) :: {map, map, map, map}
-  def declare_with_subqueues(host, work_queue) when is_atom(host) do
+  @spec declare_with_subqueues(AMQP.Connection.t() | atom, String.t(), keyword) ::
+          {map, map, map, map}
+  def declare_with_subqueues(host_or_connection, work_queue, opts \\ [])
+
+  def declare_with_subqueues(host, work_queue, opts) when is_atom(host) do
     conn = TaskBunny.Connection.get_connection!(host)
-    declare_with_subqueues(conn, work_queue)
+    declare_with_subqueues(conn, work_queue, opts)
   end
 
-  def declare_with_subqueues(connection, work_queue) do
+  def declare_with_subqueues(connection, work_queue, opts) when is_list(opts) do
     {:ok, channel} = AMQP.Channel.open(connection)
 
     scheduled_queue = scheduled_queue(work_queue)
     retry_queue = retry_queue(work_queue)
     rejected_queue = rejected_queue(work_queue)
 
-    work = declare(channel, work_queue, durable: true)
-    rejected = declare(channel, rejected_queue, durable: true)
+    queue_type_args = queue_type_arguments(opts[:queue_type])
+
+    work = declare(channel, work_queue, durable: true, arguments: queue_type_args)
+    rejected = declare(channel, rejected_queue, durable: true, arguments: queue_type_args)
 
     # Set main queue as dead letter exchange of retry queue.
     # It will requeue the message once message TTL is over.
     retry_options = [
-      arguments: [
-        {"x-dead-letter-exchange", :longstr, ""},
-        {"x-dead-letter-routing-key", :longstr, work_queue}
-      ],
+      arguments:
+        queue_type_args ++
+          [
+            {"x-dead-letter-exchange", :longstr, ""},
+            {"x-dead-letter-routing-key", :longstr, work_queue}
+          ],
       durable: true
     ]
 
     retry = declare(channel, retry_queue, retry_options)
 
     scheduled_options = [
-      arguments: [
-        {"x-dead-letter-exchange", :longstr, ""},
-        {"x-dead-letter-routing-key", :longstr, work_queue}
-      ],
+      arguments:
+        queue_type_args ++
+          [
+            {"x-dead-letter-exchange", :longstr, ""},
+            {"x-dead-letter-routing-key", :longstr, work_queue}
+          ],
       durable: true
     ]
 
@@ -67,6 +80,14 @@ defmodule TaskBunny.Queue do
     :ok = AMQP.Channel.close(channel)
 
     {work, retry, rejected, scheduled}
+  end
+
+  # No explicit type requested — omit the argument entirely, exactly as
+  # before this option existed.
+  defp queue_type_arguments(nil), do: []
+
+  defp queue_type_arguments(queue_type) when queue_type in [:quorum, :classic, :stream] do
+    [{"x-queue-type", :longstr, Atom.to_string(queue_type)}]
   end
 
   @doc """

--- a/lib/task_bunny/worker.ex
+++ b/lib/task_bunny/worker.ex
@@ -29,6 +29,7 @@ defmodule TaskBunny.Worker do
           host: atom,
           concurrency: integer,
           store_rejected_jobs: boolean,
+          queue_type: atom | nil,
           channel: AMQP.Channel.t() | nil,
           consumer_tag: String.t() | nil,
           runners: integer,
@@ -43,6 +44,7 @@ defmodule TaskBunny.Worker do
             host: :default,
             concurrency: 1,
             store_rejected_jobs: true,
+            queue_type: nil,
             channel: nil,
             consumer_tag: nil,
             runners: 0,
@@ -60,7 +62,8 @@ defmodule TaskBunny.Worker do
       host: config[:host] || :default,
       queue: config[:queue],
       concurrency: config[:concurrency],
-      store_rejected_jobs: Keyword.get(config, :store_rejected_jobs, true)
+      store_rejected_jobs: Keyword.get(config, :store_rejected_jobs, true),
+      queue_type: config[:queue_type]
     }
     |> start_link()
   end
@@ -132,7 +135,7 @@ defmodule TaskBunny.Worker do
   # Start consumer loop
   def handle_info({:connected, connection}, state = %Worker{}) do
     # Declares queue
-    Queue.declare_with_subqueues(state.host, state.queue)
+    Queue.declare_with_subqueues(state.host, state.queue, queue_type: state.queue_type)
 
     # Consumes the queue
     case Consumer.consume(connection, state.queue, state.concurrency) do

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+elixir = "1.20.1-otp-27"
+erlang = "27.3.4.12"

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule TaskBunny.Mixfile do
   use Mix.Project
 
-  @version "0.4.1"
+  @version "0.4.2"
   @description "Background processing application/library written in Elixir that uses RabbitMQ as a messaging backend"
 
   def project do

--- a/test/task_bunny/queue_test.exs
+++ b/test/task_bunny/queue_test.exs
@@ -1,0 +1,49 @@
+defmodule TaskBunny.QueueTest do
+  use ExUnit.Case, async: false
+  import TaskBunny.QueueTestHelper
+  alias TaskBunny.Queue
+
+  @queue "task_bunny.queue_test"
+
+  setup do
+    clean(Queue.queue_with_subqueues(@queue))
+    :ok
+  end
+
+  describe "declare_with_subqueues/3" do
+    test "declares classic queues (no x-queue-type argument) when queue_type is not given" do
+      {work, retry, rejected, scheduled} = Queue.declare_with_subqueues(:default, @queue)
+
+      for state <- [work, retry, rejected, scheduled] do
+        refute Enum.any?(state.arguments || [], fn {key, _, _} -> key == "x-queue-type" end)
+      end
+    end
+
+    test "declares quorum queues when queue_type: :quorum is given" do
+      Queue.declare_with_subqueues(:default, @queue, queue_type: :quorum)
+
+      {:ok, channel} = TaskBunny.QueueTestHelper.open_channel()
+
+      for queue <- Queue.queue_with_subqueues(@queue) do
+        {:ok, info} = AMQP.Queue.status(channel, queue)
+        assert info.queue == queue
+      end
+
+      # AMQP.Queue.status/2 doesn't surface arguments back, so assert via
+      # the management-free signal available to us: redeclaring with a
+      # conflicting queue_type must be rejected by the broker (406
+      # PRECONDITION_FAILED, surfaced as an :exit signal — the same failure
+      # mode TaskBunny.Initializer/Worker catch/don't-catch in production),
+      # proving the queue actually came up as quorum and not classic.
+      result =
+        try do
+          Queue.declare_with_subqueues(:default, @queue, queue_type: :classic)
+          :declared
+        catch
+          :exit, reason -> {:exit, reason}
+        end
+
+      assert {:exit, _reason} = result
+    end
+  end
+end


### PR DESCRIPTION
## Summary

RabbitMQ 3.13.x has a real bug: a vhost's `default_queue_type` metadata reporting the literal string `"undefined"` does not fall back to the node-level `rabbitmq.conf` `default_queue_type` setting (that fallback was only added upstream in 4.0.5+). On affected clusters this means `TaskBunny.Queue.declare_with_subqueues/2`'s type-less declare always resolves to `classic`, regardless of node config.

This bit controlroom QA live: after an out-of-band migration converted its `smart_rent.*` queues to quorum, every subsequent `TaskBunny.Worker` reconnect hit a `406 PRECONDITION_FAILED` on redeclare. `Worker`'s connect path has no catch around that declare call, so the `Worker` GenServer died before ever reaching `Consumer.consume` — a silent zero-consumer failure, masked by an unrelated-looking `Initializer` warning that (incorrectly) looked cosmetic in the logs.

See [TECH-9393](https://smartrent.atlassian.net/browse/TECH-9393) for the full incident writeup.

## What this does

Adds an opt-in `queue_type: :quorum | :classic | :stream` config option, threaded through `Config` → `Initializer` → `Worker` → `Queue.declare_with_subqueues/3`'s new third arg. When set, all four subqueues (main, retry, rejected, scheduled) declare `x-queue-type` explicitly, bypassing broker-side default-queue-type resolution entirely — immune to the 3.13.x bug regardless of vhost/cluster state.

- Defaults to `nil` — **zero behavior change** for any consumer that doesn't opt in (no explicit `x-queue-type` argument sent, exactly as before).
- New test (`test/task_bunny/queue_test.exs`) asserts: (a) no `x-queue-type` argument is sent when `queue_type` isn't given, and (b) a queue declared with `queue_type: :quorum` actually rejects a later `:classic` redeclare — proving the option changes real broker-side behavior, not just the call signature.
- Version bumped to `0.4.2`, CHANGELOG updated.
- `mise.toml` added to pin the toolchain (`elixir 1.20.1-otp-27`, `erlang 27.3.4.12`).

## Test plan

- [x] Compiles clean with `--warnings-as-errors` (the one pre-existing warning, `job.ex`'s unused `require Logger`, predates this branch and is untouched by it — confirmed via `git log`)
- [ ] CI runs `mix test` against the real `rabbitmq:3.8-alpine` service container — this has not yet been validated against a live broker locally, so CI is the first real test run
- [ ] Once merged and released as `0.4.2`, `control.smartrent.com` needs a follow-up PR: bump the dependency, add `queue_type: :quorum` to the `smart_rent.*` entries in `config/common/rabbitmq_queues.exs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECH-9393]: https://smartrent.atlassian.net/browse/TECH-9393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ